### PR TITLE
navi2ch-thumbnailの正規表現処理の見直し

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2011-05-16  MIZUNUMA Yuto  <mizmiz@sf.net>
+
+	* navi2ch-thumbnail.el (navi2ch-thumbnail-picto): pic.to対応追加
+	(navi2ch-thumbnail-url-coversion-table): defvar化
+	(navi2ch-thumbnail-image-url-regex-build): mapconcatで綺麗に
+
 2011-05-12  MIZUNUMA Yuto  <mizmiz@sf.net>
 
 	* navi2ch-thumbnail.el (navi2ch-thumbnail-image-pre): 複雑なURLの場


### PR DESCRIPTION
以前から気になっていた、「画像を取得するための処理が面倒なURL」の正規表現処理を一箇所にまとめてみました。
テーブルを作って、そこに正規表現と処理関数へのポインタを置きます。
結構、大幅な改修になってしまったのでエンバグしたかもしれません。
もっと効率的な方法があれば、提案よろしくお願いします。

ついでにimepicへの対応もしてみました。

落ち着いたら、コメントアウト行は一気に削除予定です。

とりあえず暫定版という感じで様子を見ながらのつもりです。
