### PR TITLE
Update thread finder URL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2013-08-21  NOKUBI Takatsugu  <knok@daionet.gr.jp>
+
+	* doc/navi2ch.texi (Getting): スレッド検索をfind.2ch.netに変更
+
 2013-06-19  MIZUNUMA Yuto  <mizmiz@sf.net>
 
 	* navi2ch-thumbnail.el (navi2ch-thumbnail-twitpic): twitter仕様変更対応

--- a/doc/navi2ch.texi
+++ b/doc/navi2ch.texi
@@ -192,7 +192,7 @@ Summary Page}も要チェック。
 @c (全部 sourceforge に移した方がいいかな。)
 
 ２ちゃんねる UNIX 板、@uref{Navi2ch スレ,
-http://h.u.la/dance/?P=1&kenken=Navi2ch}も参照のこと。
+http://find.2ch.net/?STR=navi2ch}も参照のこと。
 
 @node Compile
 @section コンパイル方法


### PR DESCRIPTION
The domain "h.u.la" seems dead.
I changed it in the document to use "find.2ch.net".
