### PR TITLE
OS Xでmonaを有効化する

### DIFF
--- a/navi2ch-mona.el
+++ b/navi2ch-mona.el
@@ -419,8 +419,7 @@ nil の場合はデフォルトで有効になる。
 
 (defun navi2ch-mona-setup ()
   "*モナーフォントを使うためのフックを追加する。"
-  (when (and (or (eq window-system 'x) (eq window-system 'w32)
-                 (eq window-system 'mac))
+  (when (and (memq window-system '(x w32 mac ns))
 	     (or navi2ch-on-emacs21 navi2ch-on-xemacs))
     (navi2ch-mona-create-face-from-family-name 
      (if navi2ch-mona-use-ipa-mona


### PR DESCRIPTION
そんなに重要な分岐ではない気がするので`memq`も省いてしまって良いかもしれない。。。
